### PR TITLE
注文履歴ページの追加

### DIFF
--- a/app/components/molecules/MenuDrawer.tsx
+++ b/app/components/molecules/MenuDrawer.tsx
@@ -15,6 +15,7 @@ type Props = {
   onClickReception: () => void
   onClickRegister: () => void
   onClickKitchen: () => void
+  onClickOrderTable: () => void
 }
 
 export const MenuDrawer: FC<Props> = memo((props) => {
@@ -25,6 +26,7 @@ export const MenuDrawer: FC<Props> = memo((props) => {
     onClickReception,
     onClickRegister,
     onClickKitchen,
+    onClickOrderTable,
   } = props
 
   return (
@@ -44,6 +46,9 @@ export const MenuDrawer: FC<Props> = memo((props) => {
             <Button w="100%" onClick={onClickKitchen}>
               厨房
             </Button>
+            <Button w="100%" onClick={onClickOrderTable}>
+              注文履歴
+            </Button>
           </DrawerBody>
         </DrawerContent>
       </DrawerOverlay>
@@ -60,4 +65,5 @@ MenuDrawer.propTypes = {
   onClickReception: PropTypes.func.isRequired,
   onClickRegister: PropTypes.func.isRequired,
   onClickKitchen: PropTypes.func.isRequired,
+  onClickOrderTable: PropTypes.func.isRequired,
 }

--- a/app/routes/header.tsx
+++ b/app/routes/header.tsx
@@ -24,6 +24,10 @@ export default function Header() {
     navigate("/kitchen")
     onClose()
   }, [navigate, onClose])
+  const onClickOrderTable = useCallback(() => {
+    navigate("/order_table")
+    onClose()
+  }, [navigate, onClose])
 
   return (
     <>
@@ -44,6 +48,7 @@ export default function Header() {
         onClickReception={onClickReception}
         onClickRegister={onClickRegister}
         onClickKitchen={onClickKitchen}
+        onClickOrderTable={onClickOrderTable}
       />
     </>
   )

--- a/app/routes/order_table.tsx
+++ b/app/routes/order_table.tsx
@@ -1,0 +1,96 @@
+import {
+  Box,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  TableCaption,
+  TableContainer,
+} from "@chakra-ui/react"
+import { json, useLoaderData } from "@remix-run/react"
+import { readDetail } from "~/crud/crud_details"
+import { readOrder } from "~/crud/crud_orders"
+import { readProduct } from "~/crud/crud_products"
+import { useKitchenData } from "~/hooks/useKitchenData"
+import { TypeDetail } from "~/type/typedetail"
+import { TypeOrder } from "~/type/typeorder"
+import { TypeProduct } from "~/type/typeproduct"
+
+export default function OrderTable() {
+  const data = useLoaderData<{
+    orders: TypeOrder[]
+    details: TypeDetail[]
+    products: TypeProduct[]
+  }>()
+
+  const { orders, details, products } = useKitchenData(
+    data.orders,
+    data.details,
+    data.products,
+  )
+
+  return (
+    <Box p={4} bg={"white"}>
+      <TableContainer>
+        <Table variant="striped" colorScheme="gray">
+          <TableCaption>注文履歴一覧</TableCaption>
+          <Thead>
+            <Tr>
+              <Th>ID</Th>
+              <Th>テーブル番号</Th>
+              <Th>注文内容</Th>
+              <Th>ステータス</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {orders.map((order) => {
+              const filteredDetails = details.filter(
+                (detail) => detail.order_id === order.order_id,
+              )
+              const productIds = filteredDetails.map(
+                (detail) => detail.product_id,
+              )
+              const filteredProducts = products.filter((product) =>
+                productIds.includes(product.product_id),
+              )
+              const productNames = filteredProducts.map(
+                (product) => product.product_name,
+              )
+              const quantities = filteredDetails.map(
+                (detail) => detail.quantity,
+              )
+
+              return (
+                <Tr key={order.order_id}>
+                  <Td>{order.order_id}</Td>
+                  <Td>{order.table_number}</Td>
+                  <Td>
+                    {productNames.map((name, index) => (
+                      <div key={index}>
+                        {name}--数量：{quantities[index]}
+                      </div>
+                    ))}
+                  </Td>
+                  <Td>{order.status}</Td>
+                </Tr>
+              )
+            })}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Box>
+  )
+}
+
+export const loader = async () => {
+  const response_orders = await readOrder()
+  const response_details = await readDetail()
+  const response_products = await readProduct()
+  return json({
+    orders: response_orders,
+    details: response_details,
+    products: response_products,
+  })
+}

--- a/app/routes/side.tsx
+++ b/app/routes/side.tsx
@@ -49,6 +49,16 @@ export default function Sidebar() {
       >
         厨房
       </Link>
+
+      <Link
+        href="/order_table"
+        mb={4}
+        p={2}
+        bg={location.pathname === "/order_table" ? "blue.200" : "transparent"}
+        borderRadius="md"
+      >
+        注文履歴
+      </Link>
     </Flex>
   )
 }


### PR DESCRIPTION
注文履歴を閲覧ができるページを追加しました。現在は、ID、テーブル番号、注文内容、ステータスだけですが、後で注文日時を追加する予定です。

close #24 