### PR TITLE
chore(CI): デプロイ用の`Dockerfile`と`compose.yaml`を整備

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore
+.git
+.gitignore
+README.md
+prisma/data
+build
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM ubuntu:24.04 AS base
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN groupadd -r appuser && useradd -r -g appuser -s /bin/false appuser
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl=8.5.0-2ubuntu10.4 \
+    unzip=6.0-28ubuntu4.1 \
+    openssl=3.0.13-0ubuntu3.4 \
+    ca-certificates=20240203 \
+    && rm -rf /var/lib/apt/lists/*
+USER appuser
+WORKDIR /home/appuser
+ENV MISE_ROOT="/home/appuser/.local/share/mise"
+ENV PATH="/home/appuser/.local/bin:${MISE_ROOT}/shims:${MISE_ROOT}/bin:${PATH}"
+RUN curl https://mise.run | bash && \
+    echo 'eval "$(~/.local/bin/mise activate bash)"' >> ~/.bashrc
+WORKDIR /app
+COPY --chown=appuser:appuser .tool-versions ./
+RUN . ~/.bashrc && mise install
+
+FROM base AS builder
+WORKDIR /app
+USER root
+RUN mkdir /app/node_modules && chown -R appuser:appuser /app
+USER appuser
+COPY --chown=appuser:appuser package.json bun.lockb ./
+RUN bun install --frozen-lockfile --verbose
+COPY --chown=appuser:appuser . .
+RUN bun prisma generate
+ENV DATABASE_URL=file:/app/prisma/data/deploy.db
+RUN mkdir -p prisma/data && \
+    touch prisma/data/deploy.db && \
+    bun prisma migrate deploy
+RUN bun run build
+USER root
+RUN bun install --frozen-lockfile --production && \
+    mkdir -p /tmp/prod/app && \
+    cp -r build /tmp/prod/app/ && \
+    cp -r node_modules /tmp/prod/app/ && \
+    cp -r prisma /tmp/prod/app/ && \
+    cp package.json /tmp/prod/app/ && \
+    chown -R 65532:65532 /tmp/prod && \
+    chmod -R 755 /tmp/prod/app && \
+    chmod 777 /tmp/prod/app/prisma/data && \
+    touch /tmp/prod/app/prisma/data/deploy.db && \
+    chmod 666 /tmp/prod/app/prisma/data/deploy.db
+
+FROM gcr.io/distroless/nodejs22-debian12:nonroot AS runner
+WORKDIR /app
+COPY --from=builder /tmp/prod/app ./
+ENV NODE_ENV=production \
+    DATABASE_URL=file:/app/prisma/data/deploy.db
+USER 65532:65532
+EXPOSE 3000
+CMD ["node_modules/@remix-run/serve/dist/cli.js", "build/server/index.js"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,20 @@
+name: order
+
+services:
+  deploy:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - sqlite_data:/app/prisma/data
+    environment:
+      - NODE_ENV=production
+      - DATABASE_URL=file:/app/prisma/data/deploy.db
+    user: "65532:65532"
+    restart: unless-stopped
+
+volumes:
+  sqlite_data:
+    name: order_sqlite_data


### PR DESCRIPTION
close #29 

## 確認事項

`docker compose up`を実行すると、`localhost:3000`で実行できる。

## Summary
This pull request introduces Docker support for the project by adding necessary configuration files and setting up the Docker environment. The most important changes include adding a `.dockerignore` file, creating a `Dockerfile` for building and running the application, and defining a `compose.yaml` file for Docker Compose.

Docker configuration:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R10): Added to exclude unnecessary files and directories from the Docker build context.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R38): Created to define the multi-stage build process for the application, including installing dependencies, generating Prisma client, running migrations, and preparing the production environment.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cR1-R20): Added to define the Docker Compose configuration for the application, specifying the service, ports, volumes, environment variables, and restart policy.