### PR TITLE
chore: コンテナがビルドできるように修正

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 name: order
 
 services:
-  deploy:
+  production:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
close #33 

## 確認事項

- `docker compose up`を実行した際に正しくビルドが出来る

### 以前のデータが残っている場合
1. `docker compose down -v`
2. `docker compose build --no-cache`
3. `docker compose up`
で確認する。

## Summary
This pull request includes significant changes to the `Dockerfile` to improve the build process and separate dependencies for different stages. The most important changes include renaming the build stage, adding new stages for dependencies, and modifying the build and production setup.

Changes to build stages and dependencies:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-L39): Renamed the `builder` stage to `prod-deps` and added a new `deps` stage for handling non-production dependencies.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-L39): Added commands to copy Prisma files and generate Prisma client during the `prod-deps` stage.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-L39): Modified the `RUN bun install` command to handle production dependencies separately and copy them to a temporary directory.

Changes to build and production setup:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L21-L39): Updated the `builder` stage to use the `deps` stage for initial setup and dependency installation.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R65): Modified the `runner` stage to copy production dependencies from the `prod-deps` stage instead of building them in the final stage.