### PR TITLE
feat: Headerのデザインを改善

### DIFF
--- a/app/components/atoms/button/MenuIconButton.tsx
+++ b/app/components/atoms/button/MenuIconButton.tsx
@@ -12,9 +12,13 @@ export const MenuIconButton: FC<Props> = memo(({ onOpen }) => {
     <IconButton
       aria-label="メニューボタン"
       icon={<HamburgerIcon />}
-      size="sm"
-      variant="unstyled"
+      size="lg"
+      variant="ghost"
       display={{ base: "block", lg: "none" }}
+      _hover={{
+        cursor: "pointer",
+        bg: "blackAlpha.100",
+      }}
       onClick={onOpen}
     />
   )

--- a/app/routes/header.tsx
+++ b/app/routes/header.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, Text, useDisclosure } from "@chakra-ui/react"
+import { Flex, Heading, HStack, Text, useDisclosure } from "@chakra-ui/react"
 import { Link, useNavigate } from "@remix-run/react"
 import { useCallback } from "react"
 import { MenuIconButton } from "~/components/atoms/button/MenuIconButton"
@@ -31,7 +31,13 @@ export default function Header() {
 
   return (
     <>
-      <Flex bg="blackAlpha.100" padding={{ base: 3, lg: 5 }}>
+      <HStack
+        bg="blackAlpha.100"
+        padding={4}
+        gap={4}
+        backdropFilter="auto"
+        backdropBlur="lg"
+      >
         <MenuIconButton onOpen={onOpen} />
         <Heading _hover={{ cursor: "pointer" }}>
           <Link to="/">
@@ -40,7 +46,7 @@ export default function Header() {
             </Text>
           </Link>
         </Heading>
-      </Flex>
+      </HStack>
       <MenuDrawer
         onClose={onClose}
         isOpen={isOpen}

--- a/app/routes/header.tsx
+++ b/app/routes/header.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, HStack, Text, useDisclosure } from "@chakra-ui/react"
+import { Heading, HStack, Text, useDisclosure } from "@chakra-ui/react"
 import { Link, useNavigate } from "@remix-run/react"
 import { useCallback } from "react"
 import { MenuIconButton } from "~/components/atoms/button/MenuIconButton"


### PR DESCRIPTION
close #48 

## Summary

This pull request includes changes to the `MenuIconButton` component and the `Header` component to improve their styling and layout.

Styling improvements:

* [`app/components/atoms/button/MenuIconButton.tsx`](diffhunk://#diff-2dd4a30fcf81e9e44e5d44b0de48824bc017858311e8e2022ed720436be7df4eL15-R21): Changed the `size` from `sm` to `lg` and the `variant` from `unstyled` to `ghost`. Added hover styles to change the cursor to a pointer and set the background to `blackAlpha.100`.

Layout improvements:

* [`app/routes/header.tsx`](diffhunk://#diff-1d59cdc77af872fc3fa322b7c5534c1fe3063d7428f9df8f46023113035a951dL34-R40): Replaced `Flex` with `HStack` in the `Header` component to better align the children elements. Added padding, gap, and backdrop filter properties to the `HStack`. [[1]](diffhunk://#diff-1d59cdc77af872fc3fa322b7c5534c1fe3063d7428f9df8f46023113035a951dL34-R40) [[2]](diffhunk://#diff-1d59cdc77af872fc3fa322b7c5534c1fe3063d7428f9df8f46023113035a951dL43-R49)
* [`app/routes/header.tsx`](diffhunk://#diff-1d59cdc77af872fc3fa322b7c5534c1fe3063d7428f9df8f46023113035a951dL1-R1): Imported `HStack` from `@chakra-ui/react` to support the layout changes in the `Header` component.