### PR TITLE
fix: 商品カードの最小サイズを画像の幅に依存しない

### DIFF
--- a/app/components/organisms/register/ProductCard.tsx
+++ b/app/components/organisms/register/ProductCard.tsx
@@ -14,8 +14,7 @@ export const ProductCard: FC<Props> = memo((props) => {
 
   return (
     <Box
-      w="full"
-      maxW="300px"
+      w="300px"
       h="fit-content"
       bg={"white"}
       borderRadius="lg"


### PR DESCRIPTION
close #51 