### PR TITLE
chore: setup ci to run build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        task: [type-check, biome]
+        task: [type-check, biome, build]
       fail-fast: false
     steps:
       - name: Checkout the repository
@@ -30,3 +30,6 @@ jobs:
       - name: Run Biome
         if: matrix.task == 'biome'
         run: bun run biome ci .
+      - name: Build
+        if: matrix.task == 'build'
+        run: bun run build


### PR DESCRIPTION
close #10 

This pull request updates the CI workflow configuration in `.github/workflows/ci.yml` to include a new build step. The most important changes are as follows:

### Updates to CI Workflow:

* Added `build` as a new task in the matrix under `jobs:` to expand the CI workflow's coverage. (`[.github/workflows/ci.ymlL18-R18](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL18-R18)`)
* Introduced a new step to run the `build` task when the matrix task is set to `build`, using the command `bun run build`. (`[.github/workflows/ci.ymlR33-R35](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR33-R35)`)