### PR TITLE
chore: reduce renovate update frequency

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
   },
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchUpdateTypes": ["minor"],
       "matchCurrentVersion": "!/^0/",
       "automerge": true
     }


### PR DESCRIPTION
close #118 
This pull request makes a small update to the `renovate.json` configuration file, changing the automerge behavior for dependency updates to only apply to minor updates, not patch updates.