### PR TITLE
feat: add string length validation to product register form

### DIFF
--- a/app/routes/staff/products/-components/$tagInput.tsx
+++ b/app/routes/staff/products/-components/$tagInput.tsx
@@ -1,5 +1,6 @@
 import { type FC, useState } from "hono/jsx"
 import type ProductTag from "../../../../domain/product/entities/productTag"
+import { stripString } from "../../../../utils/text"
 
 type TagInputProps = {
   existingTags: ProductTag[]
@@ -70,7 +71,7 @@ const TagInput: FC<TagInputProps> = ({ existingTags }) => {
           aria-haspopup="listbox"
           aria-controls="tag-suggestions"
           onInput={(e) => {
-            const value = (e.target as HTMLInputElement).value
+            const value = stripString((e.target as HTMLInputElement).value, 50)
             setInput(value)
             updateSuggestions(value)
           }}

--- a/app/routes/staff/products/-components/productRegister.tsx
+++ b/app/routes/staff/products/-components/productRegister.tsx
@@ -31,6 +31,7 @@ const ProductRegister = ({ tags }: ProductRegisterProps) => (
           <div className="mb-4">
             <label className="mb-1 block font-medium text-gray-700 text-sm">
               商品名
+              {/* TODO: サロゲートペアを考慮したクライアントバリデーションを実装する */}
               <input
                 type="text"
                 name="name"
@@ -38,7 +39,6 @@ const ProductRegister = ({ tags }: ProductRegisterProps) => (
                 placeholder="商品名を入力してください"
                 required
                 minLength={1}
-                maxLength={100}
               />
             </label>
           </div>

--- a/app/utils/text.test.ts
+++ b/app/utils/text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test"
-import { countStringLength } from "./text"
+import { countStringLength, stripString } from "./text"
 
 describe("countStringLength", () => {
   it("通常の文字列の長さを数える", () => {
@@ -10,5 +10,24 @@ describe("countStringLength", () => {
   })
   it("絵文字文字列の長さを数える", () => {
     expect(countStringLength("👩‍👩‍👧‍👦")).toStrictEqual(1)
+  })
+})
+
+describe("stripString", () => {
+  it("通常の文字列を指定文字数で切り出す", () => {
+    expect(stripString("こんにちは世界", 4)).toBe("こんにち")
+  })
+  it("サロゲートペア文字列を指定文字数で切り出す", () => {
+    expect(stripString("𠮷野家", 2)).toBe("𠮷野")
+  })
+  it("絵文字文字列を指定文字数で切り出す", () => {
+    expect(stripString("👩‍👩‍👧‍👦家", 1)).toBe("👩‍👩‍👧‍👦")
+    expect(stripString("👩‍👩‍👧‍👦家", 2)).toBe("👩‍👩‍👧‍👦家")
+  })
+  it("maxLengthが0なら空文字を返す", () => {
+    expect(stripString("テスト", 0)).toBe("")
+  })
+  it("maxLengthが元の長さ以上ならそのまま返す", () => {
+    expect(stripString("テスト", 10)).toBe("テスト")
   })
 })

--- a/app/utils/text.ts
+++ b/app/utils/text.ts
@@ -13,3 +13,20 @@ export const countStringLength = (input: string): number => {
   const segments = segmenter.segment(input)
   return [...segments].length
 }
+
+/**
+ * サロゲートペアや結合文字を考慮して、指定した文字数で安全に切り出す
+ *
+ * @param input - 切り出す文字列
+ * @param maxLength - 最大文字数
+ * @returns 指定文字数で切り詰めた文字列
+ * @example
+ * stripString("👩‍👩‍👧‍👦家", 2) // => "👩‍👩‍👧‍👦家"
+ */
+export const stripString = (input: string, maxLength: number): string => {
+  const segmenter = new Intl.Segmenter("ja", { granularity: "grapheme" })
+  const segments = segmenter.segment(input)
+  return Array.from(segments, (s) => s.segment)
+    .slice(0, maxLength)
+    .join("")
+}

--- a/app/utils/text.ts
+++ b/app/utils/text.ts
@@ -21,7 +21,7 @@ export const countStringLength = (input: string): number => {
  * @param maxLength - 最大文字数
  * @returns 指定文字数で切り詰めた文字列
  * @example
- * stripString("👩‍👩‍👧‍👦家", 2) // => "👩‍👩‍👧‍👦家"
+ * stripString("👩‍👩‍👧‍👦家族", 2) // => "👩‍👩‍👧‍👦家"
  */
 export const stripString = (input: string, maxLength: number): string => {
   const segmenter = new Intl.Segmenter("ja", { granularity: "grapheme" })


### PR DESCRIPTION
## 変更点

- 商品登録フォームの商品名入力欄の`maxLength`属性を削除した
- 商品登録フォームのタグ入力欄にサロゲートペアを考慮した文字数のバリデーションを追加した
