### PR TITLE
chore: add `process.env` support to Vite configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import honox from "honox/vite"
 import { defineConfig } from "vite"
 
 export default defineConfig({
+  define: {
+    // https://github.com/honojs/honox/issues/307
+    "process.env": "process.env",
+  },
   plugins: [
     honox({
       devServer: { adapter },


### PR DESCRIPTION
## 変更点

- ビルドしたアプリケーションで環境変数が利用できるようにViteの設定を追加した