### PR TITLE
chore: add PGLite support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ lerna-debug.log*
 
 # misc
 .DS_Store
+
+# database
+drizzle/
+drizzle-test/
+pgdata/

--- a/app/global.d.ts
+++ b/app/global.d.ts
@@ -1,5 +1,9 @@
 import type {} from "hono"
 
 declare module "hono" {
-  interface Env {}
+  interface Env {
+    Variables: {
+      dbClient: import("./infrastructure/db/client").DbClient
+    }
+  }
 }

--- a/app/infrastructure/db/client.ts
+++ b/app/infrastructure/db/client.ts
@@ -1,10 +1,16 @@
-import { drizzle } from "drizzle-orm/postgres-js"
 import * as schema from "./schema"
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is not set.")
-}
-export const dbClient = drizzle(process.env.DATABASE_URL, { schema })
+export const dbClient = await (async () => {
+  if (!process.env.DATABASE_URL) {
+    console.warn(`DATABASE_URL environment variable is not set.
+Using native filesystem Postgres database via PGLite for testing purposes.`)
+
+    const { drizzle } = await import("drizzle-orm/pglite")
+    return drizzle("./pgdata", { schema })
+  }
+  const { drizzle } = await import("drizzle-orm/postgres-js")
+  return drizzle(process.env.DATABASE_URL, { schema })
+})()
 
 /** Query系で利用するDBクライアント */
 export type DbClient = typeof dbClient

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -1,0 +1,10 @@
+import { createMiddleware } from "hono/factory"
+import { createRoute } from "honox/factory"
+import { createDbClient } from "../infrastructure/db/client"
+
+export default createRoute(
+  createMiddleware(async (c, next) => {
+    c.set("dbClient", await createDbClient())
+    await next()
+  }),
+)

--- a/app/routes/staff/products/index.tsx
+++ b/app/routes/staff/products/index.tsx
@@ -20,7 +20,7 @@ import ViewModeToggle from "./-components/viewModeToggle"
 
 const productFormDataToRegisterProductParams = (
   formData: FormData,
-): RegisterProductParams => {
+): RegisterProductParams["product"] => {
   const name = String(formData.get("name") ?? "").trim()
   if (!name) throw new Error("商品名は必須です")
   if (countStringLength(name) < 1 || countStringLength(name) > 50)
@@ -59,7 +59,7 @@ export const POST = createRoute(async (c) => {
   try {
     const formData = await c.req.formData()
     const product = productFormDataToRegisterProductParams(formData)
-    await registerProduct(product)
+    await registerProduct({ dbClient: c.get("dbClient"), product })
 
     setToastCookie(c, "success", "商品を登録しました")
   } catch (e) {
@@ -85,7 +85,7 @@ export default createRoute(async (c) => {
     outOfStockCount,
     lowStockCount,
     totalValue,
-  } = await getProductsManagementPageData()
+  } = await getProductsManagementPageData({ dbClient: c.get("dbClient") })
 
   return c.render(
     <Layout title={"商品管理"} description={"商品情報の登録や編集を行います。"}>

--- a/app/usecases/getProductsManagementPageData.test.ts
+++ b/app/usecases/getProductsManagementPageData.test.ts
@@ -11,6 +11,7 @@ import type Product from "../domain/product/entities/product"
 import type ProductTag from "../domain/product/entities/productTag"
 import * as productQueryRepository from "../domain/product/repositories/productQueryRepository"
 import * as productTagQueryRepository from "../domain/product/repositories/productTagQueryRepository"
+import type { DbClient } from "../infrastructure/db/client"
 
 if (!process.env.DATABASE_URL) {
   process.env.DATABASE_URL = "postgres://localhost:5432/test"
@@ -52,6 +53,8 @@ const mockProducts: Product[] = [
   },
 ]
 
+const dbClient = {} as DbClient
+
 describe("getProductsManagementPageData", () => {
   beforeAll(() => {
     spyOn(productQueryRepository, "findAllProducts").mockImplementation(
@@ -66,7 +69,7 @@ describe("getProductsManagementPageData", () => {
   })
 
   it("商品・タグ・集計値を正しく取得できる", async () => {
-    const result = await getProductsManagementPageData()
+    const result = await getProductsManagementPageData({ dbClient })
     expect(result.tags).toEqual(mockTags)
     expect(result.products.length).toBe(3)
 
@@ -90,7 +93,7 @@ describe("getProductsManagementPageData", () => {
       async () => modifiedProducts,
     )
 
-    const result = await getProductsManagementPageData()
+    const result = await getProductsManagementPageData({ dbClient })
     expect(result.products.length).toBeGreaterThan(0)
     const first = result.products[0]
     if (!first) throw new Error("no products returned")

--- a/app/usecases/getProductsManagementPageData.ts
+++ b/app/usecases/getProductsManagementPageData.ts
@@ -2,7 +2,11 @@ import type Product from "../domain/product/entities/product"
 import type ProductTag from "../domain/product/entities/productTag"
 import { findAllProducts } from "../domain/product/repositories/productQueryRepository"
 import { findAllProductTags } from "../domain/product/repositories/productTagQueryRepository"
-import { dbClient } from "../infrastructure/db/client"
+import type { DbClient } from "../infrastructure/db/client"
+
+export type GetProductsManagementPageDataParams = {
+  dbClient: DbClient
+}
 
 export type ProductsManagementPageData = {
   products: (Omit<Product, "image" | "tagIds"> & {
@@ -16,36 +20,35 @@ export type ProductsManagementPageData = {
   totalValue: number
 }
 
-export const getProductsManagementPageData =
-  async (): Promise<ProductsManagementPageData> => {
-    const products = await findAllProducts({ dbClient })
-    const tags = await findAllProductTags({ dbClient })
-    const tagMap = new Map<number, string>(
-      tags.map((tag) => [tag.id, tag.name]),
-    )
+export const getProductsManagementPageData = async ({
+  dbClient,
+}: GetProductsManagementPageDataParams): Promise<ProductsManagementPageData> => {
+  const products = await findAllProducts({ dbClient })
+  const tags = await findAllProductTags({ dbClient })
+  const tagMap = new Map<number, string>(tags.map((tag) => [tag.id, tag.name]))
 
-    const managementProducts = products.map((product) => ({
-      ...product,
-      // TODO: デフォルト画像を正式なものに差し替える
-      image: product.image ?? "https://picsum.photos/200/200",
-      tags: product.tagIds
-        .map((tagId) => tagMap.get(tagId))
-        .filter((name): name is string => !!name),
-    }))
+  const managementProducts = products.map((product) => ({
+    ...product,
+    // TODO: デフォルト画像を正式なものに差し替える
+    image: product.image ?? "https://picsum.photos/200/200",
+    tags: product.tagIds
+      .map((tagId) => tagMap.get(tagId))
+      .filter((name): name is string => !!name),
+  }))
 
-    const totalProducts = products.length
-    const lowStockCount = products.filter(
-      (p) => p.stock <= 5 && p.stock > 0,
-    ).length
-    const outOfStockCount = products.filter((p) => p.stock === 0).length
-    const totalValue = products.reduce((sum, p) => sum + p.price * p.stock, 0)
+  const totalProducts = products.length
+  const lowStockCount = products.filter(
+    (p) => p.stock <= 5 && p.stock > 0,
+  ).length
+  const outOfStockCount = products.filter((p) => p.stock === 0).length
+  const totalValue = products.reduce((sum, p) => sum + p.price * p.stock, 0)
 
-    return {
-      products: managementProducts,
-      tags,
-      totalProducts,
-      lowStockCount,
-      outOfStockCount,
-      totalValue,
-    }
+  return {
+    products: managementProducts,
+    tags,
+    totalProducts,
+    lowStockCount,
+    outOfStockCount,
+    totalValue,
   }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "2.1.4",
+        "@electric-sql/pglite": "^0.3.9",
         "@hono/vite-build": "1.7.0",
         "@hono/vite-dev-server": "0.19.0",
         "@tailwindcss/vite": "4.1.13",
@@ -64,6 +65,8 @@
     "@dependents/detective-less": ["@dependents/detective-less@5.0.1", "", { "dependencies": { "gonzales-pe": "^4.3.0", "node-source-walk": "^7.0.1" } }, "sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.3.9", "", {}, "sha512-7S0uzvxA2HqvK8uaDKr2T12C0fq2OMxVyM8eaoIZjtqBJDYURfjORa4aYwk/fOnLwx5d6b4n7n0mcpOzNGlLwg=="],
 
     "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
 

--- a/drizzle-test.config.ts
+++ b/drizzle-test.config.ts
@@ -1,0 +1,41 @@
+/**
+ * テスト環境のためのDrizzle Kitの設定ファイル
+ */
+import { Readable, Writable } from "node:stream"
+import zlib from "node:zlib"
+import { defineConfig } from "drizzle-kit"
+
+/**
+ * This is a polyfill for the CompressionStream.
+ * This solves the issue where Drizzle Studio Can't find variable: CompressionStream
+ *
+ * ![BUG]: ReferenceError: Can't find variable: CompressionStream
+ * @see https://github.com/drizzle-team/drizzle-orm/issues/3880
+ *
+ * Bun doesn't have CompressionStream yet
+ * @see https://github.com/oven-sh/bun/issues/1723
+ */
+// @ts-expect-error
+globalThis.CompressionStream ??= class CompressionStream {
+  readable
+  writable
+  constructor(format: "deflate" | "deflate-raw" | "gzip") {
+    const handle = {
+      deflate: zlib.createDeflate,
+      "deflate-raw": zlib.createDeflateRaw,
+      gzip: zlib.createGzip,
+    }[format]()
+    this.readable = Readable.toWeb(handle)
+    this.writable = Writable.toWeb(handle)
+  }
+}
+
+export default defineConfig({
+  out: "./drizzle-test",
+  schema: "./app/infrastructure/db/schema.ts",
+  dialect: "postgresql",
+  driver: "pglite",
+  dbCredentials: {
+    url: "./pgdata",
+  },
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format": "biome format . && bun run prettier:format",
     "format:write": "biome format --write . && bun run prettier:format:write",
     "prettier:format": "prettier --ignore-path .prettierignore --ignore-path .gitignore --check .",
-    "prettier:format:write": "prettier --ignore-path .prettierignore --ignore-path .gitignore --write ."
+    "prettier:format:write": "prettier --ignore-path .prettierignore --ignore-path .gitignore --write .",
+    "setup-test-db": "drizzle-kit push --config drizzle-test.config.ts"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.1.4",
+    "@electric-sql/pglite": "^0.3.9",
     "@hono/vite-build": "1.7.0",
     "@hono/vite-dev-server": "0.19.0",
     "@tailwindcss/vite": "4.1.13",


### PR DESCRIPTION
close #116

## 変更点

- DrizzleのクライアントをHonoのContextで注入するように変更した
- 環境変数`DATABASE_URL`が未定義のときにPGLiteを利用するように変更した

## 確認方法

Drizzle KitでPGLiteのデータベースを初期化する。

```sh
bun --bun drizzle-kit push --config drizzle-test.config.ts
```

環境変数を未定義にして開発サーバーを起動する。

```sh
DATABASE_URL="" bun run --bun dev
```
