### PR TITLE
feat: add product name uniqueness validation in domain layer

### DIFF
--- a/app/domain/product/repositories/productQueryRepository.test.ts
+++ b/app/domain/product/repositories/productQueryRepository.test.ts
@@ -11,8 +11,10 @@ import type { DbClient } from "../../../infrastructure/db/client"
 import type Product from "../entities/product"
 import {
   type FindAllProducts,
+  type FindProductByName,
   findAllProducts,
   findProductById,
+  findProductByName,
 } from "./productQueryRepository"
 import * as productTagQueryRepository from "./productTagQueryRepository"
 
@@ -79,6 +81,157 @@ describe("findProductById", () => {
     })
     expect(result).toBeNull()
     expect(findAllProductTagsSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("findProductByName", () => {
+  let findAllProductTagsSpy: ReturnType<typeof spyOn>
+  const mockDbClient = {} as DbClient
+
+  beforeEach(() => {
+    findAllProductTagsSpy = spyOn(
+      productTagQueryRepository,
+      "findAllProductTags",
+    ).mockImplementation(async () => mockTags)
+  })
+
+  afterEach(() => {
+    mock.restore()
+  })
+
+  it("存在する商品名で商品を取得し、存在しないタグIDは除外される", async () => {
+    const mockImpl: FindProductByName = async ({ product }) =>
+      mockProducts.find((p) => p.name === product.name) ?? null
+
+    const result = await findProductByName({
+      product: { name: "テスト商品A" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(1)
+    expect(result?.name).toBe("テスト商品A")
+    expect(result?.tagIds).toEqual([1, 2])
+    expect(findAllProductTagsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("存在しない商品名ならnullを返す", async () => {
+    const mockImpl: FindProductByName = async ({ product }) =>
+      mockProducts.find((p) => p.name === product.name) ?? null
+
+    const result = await findProductByName({
+      product: { name: "存在しない商品" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result).toBeNull()
+    expect(findAllProductTagsSpy).not.toHaveBeenCalled()
+  })
+
+  it("商品名で正しい商品が取得される", async () => {
+    const mockImpl: FindProductByName = async ({ product }) =>
+      mockProducts.find((p) => p.name === product.name) ?? null
+
+    const result = await findProductByName({
+      product: { name: "テスト商品B" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result).not.toBeNull()
+    expect(result?.id).toBe(2)
+    expect(result?.name).toBe("テスト商品B")
+    expect(result?.price).toBe(200)
+    expect(result?.stock).toBe(5)
+    expect(result?.tagIds).toEqual([2])
+    expect(findAllProductTagsSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("大文字小文字を区別して検索される", async () => {
+    const caseSensitiveProducts: Product[] = [
+      {
+        id: 1,
+        name: "Product",
+        image: null,
+        tagIds: [1],
+        price: 100,
+        stock: 10,
+      },
+      {
+        id: 2,
+        name: "product",
+        image: null,
+        tagIds: [1],
+        price: 200,
+        stock: 5,
+      },
+    ]
+
+    const mockImpl: FindProductByName = async ({ product }) =>
+      caseSensitiveProducts.find((p) => p.name === product.name) ?? null
+
+    const result1 = await findProductByName({
+      product: { name: "Product" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result1?.id).toBe(1)
+
+    const result2 = await findProductByName({
+      product: { name: "product" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result2?.id).toBe(2)
+  })
+
+  it("空文字の商品名でもリポジトリ実装が呼ばれる", async () => {
+    const mockImpl: FindProductByName = async () => null
+
+    const result = await findProductByName({
+      product: { name: "" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result).toBeNull()
+    expect(findAllProductTagsSpy).not.toHaveBeenCalled()
+  })
+
+  it("特殊文字を含む商品名でも正しく検索される", async () => {
+    const specialProducts: Product[] = [
+      {
+        id: 1,
+        name: "商品@#$%",
+        image: null,
+        tagIds: [1],
+        price: 100,
+        stock: 10,
+      },
+      {
+        id: 2,
+        name: "商品'\"\\",
+        image: null,
+        tagIds: [1],
+        price: 200,
+        stock: 5,
+      },
+    ]
+
+    const mockImpl: FindProductByName = async ({ product }) =>
+      specialProducts.find((p) => p.name === product.name) ?? null
+
+    const result1 = await findProductByName({
+      product: { name: "商品@#$%" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result1?.id).toBe(1)
+
+    const result2 = await findProductByName({
+      product: { name: "商品'\"\\" },
+      repositoryImpl: mockImpl,
+      dbClient: mockDbClient,
+    })
+    expect(result2?.id).toBe(2)
   })
 })
 

--- a/app/domain/product/repositories/productQueryRepository.test.ts
+++ b/app/domain/product/repositories/productQueryRepository.test.ts
@@ -85,15 +85,7 @@ describe("findProductById", () => {
 })
 
 describe("findProductByName", () => {
-  let findAllProductTagsSpy: ReturnType<typeof spyOn>
   const mockDbClient = {} as DbClient
-
-  beforeEach(() => {
-    findAllProductTagsSpy = spyOn(
-      productTagQueryRepository,
-      "findAllProductTags",
-    ).mockImplementation(async () => mockTags)
-  })
 
   afterEach(() => {
     mock.restore()
@@ -111,8 +103,7 @@ describe("findProductByName", () => {
     expect(result).not.toBeNull()
     expect(result?.id).toBe(1)
     expect(result?.name).toBe("テスト商品A")
-    expect(result?.tagIds).toEqual([1, 2])
-    expect(findAllProductTagsSpy).toHaveBeenCalledTimes(1)
+    expect(result?.tagIds).toEqual([1, 2, 999])
   })
 
   it("存在しない商品名ならnullを返す", async () => {
@@ -125,7 +116,6 @@ describe("findProductByName", () => {
       dbClient: mockDbClient,
     })
     expect(result).toBeNull()
-    expect(findAllProductTagsSpy).not.toHaveBeenCalled()
   })
 
   it("商品名で正しい商品が取得される", async () => {
@@ -143,7 +133,6 @@ describe("findProductByName", () => {
     expect(result?.price).toBe(200)
     expect(result?.stock).toBe(5)
     expect(result?.tagIds).toEqual([2])
-    expect(findAllProductTagsSpy).toHaveBeenCalledTimes(1)
   })
 
   it("大文字小文字を区別して検索される", async () => {
@@ -193,7 +182,6 @@ describe("findProductByName", () => {
       dbClient: mockDbClient,
     })
     expect(result).toBeNull()
-    expect(findAllProductTagsSpy).not.toHaveBeenCalled()
   })
 
   it("特殊文字を含む商品名でも正しく検索される", async () => {

--- a/app/domain/product/repositories/productQueryRepository.ts
+++ b/app/domain/product/repositories/productQueryRepository.ts
@@ -40,14 +40,7 @@ export const findProductByName: WithRepositoryImpl<FindProductByName> = async ({
   repositoryImpl = findProductByNameImpl,
   dbClient,
 }) => {
-  const found = await repositoryImpl({ product, dbClient })
-  if (!found) return null
-  const tags = await findAllProductTags({ dbClient })
-  const tagIdSet = new Set(tags.map((t) => t.id))
-  return {
-    ...found,
-    tagIds: found.tagIds.filter((tagId) => tagIdSet.has(tagId)),
-  }
+  return repositoryImpl({ product, dbClient })
 }
 
 export const findAllProducts: WithRepositoryImpl<FindAllProducts> = async ({

--- a/app/infrastructure/domain/product/productQueryRepositoryImpl.ts
+++ b/app/infrastructure/domain/product/productQueryRepositoryImpl.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm"
 import type {
   FindAllProducts,
   FindProductById,
+  FindProductByName,
 } from "../../../domain/product/repositories/productQueryRepository"
 import { productTable } from "../../db/schema"
 
@@ -21,6 +22,31 @@ export const findProductByIdImpl: FindProductById = async ({
   })
   if (!dbProduct) return null
 
+  return {
+    id: dbProduct.id,
+    name: dbProduct.name,
+    image: dbProduct.image,
+    tagIds: dbProduct.productTags.map((tag) => tag.tagId),
+    price: dbProduct.price,
+    stock: dbProduct.stock,
+  }
+}
+
+export const findProductByNameImpl: FindProductByName = async ({
+  dbClient,
+  product,
+}) => {
+  const dbProduct = await dbClient.query.productTable.findFirst({
+    where: eq(productTable.name, product.name),
+    with: {
+      productTags: {
+        columns: {
+          tagId: true,
+        },
+      },
+    },
+  })
+  if (!dbProduct) return null
   return {
     id: dbProduct.id,
     name: dbProduct.name,


### PR DESCRIPTION
close #124 

## 変更点

- 商品リポジトリに商品名で検索する`findProductByName`関数を追加した
- 商品作成時に同じ名前の商品が既に存在する場合、ドメイン層でエラーを返すようにした
- 商品更新時に他の商品と名前が重複する場合、ドメイン層でエラーを返すようにした（自身の名前は許容）
- 商品名の一意性検証に関するテストケースを追加した