### PR TITLE
chore: exclude dependency management files for Renovate in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,8 @@
 * @sou1118 @3w36zj6 @r4ai
+
+# Exclude dependency management files for Renovate
+/mise.toml
+/package.json
+/bun.lock
+/.github/workflows/*
+/biome.jsonc


### PR DESCRIPTION
## 変更点

- Renovateが管理するファイルをCODEOWNERSから除外した
	- [Example of a CODEOWNERS file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file)