### PR TITLE
feat: add whitespace nowrap to badge for improved layout

### DIFF
--- a/app/components/ui/badge.tsx
+++ b/app/components/ui/badge.tsx
@@ -2,7 +2,7 @@ import type { PropsWithChildren } from "hono/jsx"
 import { tv } from "tailwind-variants"
 
 const badgeTv = tv({
-  base: "inline-block rounded-full px-3 py-1 font-medium text-xs",
+  base: "inline-block whitespace-nowrap rounded-full px-3 py-1 font-medium text-xs",
   variants: {
     variant: {
       default: "bg-muted text-muted-fg",


### PR DESCRIPTION
## 変更点

- バッジコンポーネント内のテキストの折り返しを禁止にした