### PR TITLE
fix: apply ETag only to non-JSON responses

### DIFF
--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -12,7 +12,7 @@ export default createRoute(
   createMiddleware(async (c, next) => {
     await next()
     const contentType = (c.res.headers.get("content-type") || "").toLowerCase()
-    if (!contentType || contentType.includes("json")) {
+    if (contentType?.includes("json")) {
       return
     }
     const eTagHandler = etag()

--- a/app/routes/_middleware.ts
+++ b/app/routes/_middleware.ts
@@ -8,5 +8,14 @@ export default createRoute(
     c.set("dbClient", await createDbClient())
     await next()
   }),
-  etag(),
+  // https://github.com/honojs/hono/issues/4031
+  createMiddleware(async (c, next) => {
+    await next()
+    const contentType = (c.res.headers.get("content-type") || "").toLowerCase()
+    if (!contentType || contentType.includes("json")) {
+      return
+    }
+    const eTagHandler = etag()
+    await eTagHandler(c, async () => {})
+  }),
 )

--- a/tests/integration/middleware-etag.test.ts
+++ b/tests/integration/middleware-etag.test.ts
@@ -14,19 +14,20 @@ describe("ETag Middleware", () => {
     expect(res2.status).toBe(304)
   })
 
-  test("JSON APIエンドポイントにETagが設定され、条件付きGETが304を返す", async () => {
+  test("JSON APIエンドポイントではETagが設定されない", async () => {
     const res = await app.request("/api/order-progress-manager")
     expect(res.status).toBe(200)
-    const etag = res.headers.get("etag")
-    expect(etag).toBeTruthy()
+    expect(res.headers.get("etag")).toBeNull()
 
     const json = await res.json()
     expect(json).toBeTruthy()
 
     const res2 = await app.request("/api/order-progress-manager", {
-      headers: { "If-None-Match": String(etag) },
+      headers: { "If-None-Match": "dummy" },
     })
-    expect(res2.status).toBe(304)
+    expect(res2.status).toBe(200)
+    const json2 = await res2.json()
+    expect(json2).toBeTruthy()
   })
 
   test("画像エンドポイントにETagが設定され、条件付きGETが304を返す", async () => {

--- a/tests/integration/middleware-etag.test.ts
+++ b/tests/integration/middleware-etag.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest"
+import { app } from "./utils"
+
+describe("ETag Middleware", () => {
+  test("HTMLページにETagが設定され、条件付きGETが304を返す", async () => {
+    const res = await app.request("/")
+    expect(res.status).toBe(200)
+    const etag = res.headers.get("etag")
+    expect(etag).toBeTruthy()
+
+    const res2 = await app.request("/", {
+      headers: { "If-None-Match": String(etag) },
+    })
+    expect(res2.status).toBe(304)
+  })
+
+  test("JSON APIエンドポイントにETagが設定され、条件付きGETが304を返す", async () => {
+    const res = await app.request("/api/order-progress-manager")
+    expect(res.status).toBe(200)
+    const etag = res.headers.get("etag")
+    expect(etag).toBeTruthy()
+
+    const json = await res.json()
+    expect(json).toBeTruthy()
+
+    const res2 = await app.request("/api/order-progress-manager", {
+      headers: { "If-None-Match": String(etag) },
+    })
+    expect(res2.status).toBe(304)
+  })
+
+  test("画像エンドポイントにETagが設定され、条件付きGETが304を返す", async () => {
+    const res = await app.request("/images/products/1")
+    expect(res.status).toBe(200)
+    const etag = res.headers.get("etag")
+    expect(etag).toBeTruthy()
+    const size = (await res.arrayBuffer()).byteLength
+    expect(size).toBeGreaterThan(0)
+
+    const res2 = await app.request("/images/products/1", {
+      headers: { "If-None-Match": String(etag) },
+    })
+    expect(res2.status).toBe(304)
+  })
+})


### PR DESCRIPTION
## 変更点

- JSON APIにETagを付与しないように変更した