### PR TITLE
fix: make sidebar scrollable for smartphones

### DIFF
--- a/app/routes/staff/-components/$sidebar.tsx
+++ b/app/routes/staff/-components/$sidebar.tsx
@@ -96,7 +96,7 @@ const SidebarInternal = ({
 }) => (
   <aside
     className={twJoin(
-      "fixed top-0 left-0 flex h-screen w-64 flex-col border-sidebar-border border-r bg-sidebar text-sidebar-fg",
+      "fixed top-0 left-0 flex h-screen w-64 flex-col overflow-y-auto border-sidebar-border border-r bg-sidebar text-sidebar-fg",
       className,
     )}
   >


### PR DESCRIPTION
Enable vertical scrolling in the sidebar to improve usability on smartphone devices.

![レコーディング 2025-11-22 020011](https://github.com/user-attachments/assets/099a812e-7dea-401d-9af0-9635087847e3)
