### PR TITLE
feat: add order sorting

### DIFF
--- a/app/components/ui/itemCollectionViewer.tsx
+++ b/app/components/ui/itemCollectionViewer.tsx
@@ -12,12 +12,15 @@ const itemCollectionTv = tv({
   slots: {
     container: "rounded-lg border bg-bg p-6",
     header: "mb-4 flex flex-col items-start justify-between gap-4 sm:flex-row",
-    title: "font-bold text-lg",
-    toggleContainer: "flex flex-wrap items-center gap-2 sm:flex-nowrap",
+    title: "whitespace-nowrap font-bold text-lg",
+    toggleContainer:
+      "flex flex-wrap items-center gap-4 sm:flex-nowrap sm:gap-6",
     toggleLabel: "whitespace-nowrap font-medium text-muted-fg text-sm",
     toggleGroup:
       "flex w-full items-center gap-x-1 rounded-lg bg-muted p-1 sm:w-auto",
     toggleButton:
+      "flex h-8 flex-1 items-center justify-center whitespace-nowrap rounded-md px-3 font-medium text-sm transition sm:flex-none",
+    sortButton:
       "flex h-8 flex-1 items-center justify-center whitespace-nowrap rounded-md px-3 font-medium text-sm transition sm:flex-none",
     toggleIcon: "mr-2 h-4 w-4",
     emptyState: "py-12 text-center text-lg text-muted-fg",
@@ -66,9 +69,12 @@ const itemCollectionTv = tv({
       true: {
         toggleButton:
           "pointer-events-none bg-primary-subtle text-primary-subtle-fg",
+        sortButton:
+          "pointer-events-none bg-primary-subtle text-primary-subtle-fg",
       },
       false: {
         toggleButton: "hover:bg-secondary",
+        sortButton: "hover:bg-secondary",
       },
     },
   },
@@ -201,6 +207,7 @@ type ItemCollectionViewerProps = {
   emptyMessage?: string
   currentPage: number
   hasNextPage: boolean
+  sort?: "asc" | "desc"
 }
 
 const ItemCollectionViewer = ({
@@ -212,6 +219,7 @@ const ItemCollectionViewer = ({
   emptyMessage = "データがありません",
   currentPage,
   hasNextPage,
+  sort = "asc",
 }: ItemCollectionViewerProps) => {
   const styles = itemCollectionTv()
 
@@ -220,30 +228,57 @@ const ItemCollectionViewer = ({
       <div className={styles.header()}>
         <h2 className={styles.title()}>{title}</h2>
         <div className={styles.toggleContainer()}>
-          <span className={styles.toggleLabel()}>表示モード</span>
-          <div className={styles.toggleGroup()}>
-            <a
-              href={setQueryParam(urlSearch, "view", "table")}
-              className={styles.toggleButton({
-                isActive: viewMode === "table",
-              })}
-              aria-current={viewMode === "table" ? "page" : undefined}
-            >
-              <div className={styles.toggleIcon()}>
-                <TableIcon />
-              </div>
-              テーブル
-            </a>
-            <a
-              href={setQueryParam(urlSearch, "view", "card")}
-              className={styles.toggleButton({ isActive: viewMode === "card" })}
-              aria-current={viewMode === "card" ? "page" : undefined}
-            >
-              <div className={styles.toggleIcon()}>
-                <Grid3X3Icon />
-              </div>
-              カード
-            </a>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="whitespace-nowrap font-medium text-muted-fg text-sm">
+              順序
+            </span>
+            <div className="flex items-center gap-x-1 rounded-lg bg-muted p-1">
+              <a
+                href={setQueryParam(urlSearch, "sort", "asc")}
+                className={styles.sortButton({
+                  isActive: sort === "asc",
+                })}
+              >
+                昇順
+              </a>
+              <a
+                href={setQueryParam(urlSearch, "sort", "desc")}
+                className={styles.sortButton({
+                  isActive: sort === "desc",
+                })}
+              >
+                降順
+              </a>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={styles.toggleLabel()}>表示モード</span>
+            <div className={styles.toggleGroup()}>
+              <a
+                href={setQueryParam(urlSearch, "view", "table")}
+                className={styles.toggleButton({
+                  isActive: viewMode === "table",
+                })}
+                aria-current={viewMode === "table" ? "page" : undefined}
+              >
+                <div className={styles.toggleIcon()}>
+                  <TableIcon />
+                </div>
+                テーブル
+              </a>
+              <a
+                href={setQueryParam(urlSearch, "view", "card")}
+                className={styles.toggleButton({
+                  isActive: viewMode === "card",
+                })}
+                aria-current={viewMode === "card" ? "page" : undefined}
+              >
+                <div className={styles.toggleIcon()}>
+                  <Grid3X3Icon />
+                </div>
+                カード
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/app/domain/order/repositories/orderQueryRepository.ts
+++ b/app/domain/order/repositories/orderQueryRepository.ts
@@ -1,7 +1,8 @@
 import {
   findAllOrdersByActiveStatusByUpdatedAtAscImpl,
   findAllOrdersByInactiveStatusByUpdatedAtDescImpl,
-  findAllOrdersImpl,
+  findAllOrdersOrderByIdAscImpl,
+  findAllOrdersOrderByIdDescImpl,
   findOrderByIdImpl,
 } from "../../../infrastructure/domain/order/orderQueryRepositoryImpl"
 import type {
@@ -15,7 +16,11 @@ export type FindOrderById = QueryRepositoryFunction<
   { order: Pick<Order, "id"> },
   Order | null
 >
-export type FindAllOrders = PaginatedQueryRepositoryFunction<
+export type FindAllOrdersOrderByIdAsc = PaginatedQueryRepositoryFunction<
+  Record<string, never>,
+  Order
+>
+export type FindAllOrdersOrderByIdDesc = PaginatedQueryRepositoryFunction<
   Record<string, never>,
   Order
 >
@@ -32,14 +37,25 @@ export const findOrderById: WithRepositoryImpl<FindOrderById> = async ({
   return repositoryImpl({ order, dbClient })
 }
 
-export const findAllOrders: WithRepositoryImpl<FindAllOrders> = async ({
-  repositoryImpl = findAllOrdersImpl,
+export const findAllOrdersOrderByIdAsc: WithRepositoryImpl<
+  FindAllOrdersOrderByIdAsc
+> = async ({
+  repositoryImpl = findAllOrdersOrderByIdAscImpl,
   dbClient,
   pagination,
 }) => {
   return repositoryImpl({ dbClient, pagination })
 }
 
+export const findAllOrdersOrderByIdDesc: WithRepositoryImpl<
+  FindAllOrdersOrderByIdDesc
+> = async ({
+  repositoryImpl = findAllOrdersOrderByIdDescImpl,
+  dbClient,
+  pagination,
+}) => {
+  return repositoryImpl({ dbClient, pagination })
+}
 export const findAllOrdersByActiveStatusOrderByUpdatedAtAsc: WithRepositoryImpl<
   FindAllOrdersByActiveStatusOrderByUpdatedAtAsc
 > = async ({

--- a/app/infrastructure/domain/order/orderQueryRepositoryImpl.ts
+++ b/app/infrastructure/domain/order/orderQueryRepositoryImpl.ts
@@ -1,8 +1,9 @@
 import { asc, desc, eq, inArray } from "drizzle-orm"
 import type {
-  FindAllOrders,
   FindAllOrdersByActiveStatusOrderByUpdatedAtAsc,
   FindAllOrdersByInactiveStatusOrderByUpdatedAtDesc,
+  FindAllOrdersOrderByIdAsc,
+  FindAllOrdersOrderByIdDesc,
   FindOrderById,
 } from "../../../domain/order/repositories/orderQueryRepository"
 import { orderTable } from "../../db/schema"
@@ -33,7 +34,7 @@ export const findOrderByIdImpl: FindOrderById = async ({ dbClient, order }) => {
   }
 }
 
-export const findAllOrdersImpl: FindAllOrders = async ({
+export const findAllOrdersOrderByIdAscImpl: FindAllOrdersOrderByIdAsc = async ({
   dbClient,
   pagination,
 }) => {
@@ -62,6 +63,34 @@ export const findAllOrdersImpl: FindAllOrders = async ({
   }))
   return orders
 }
+
+export const findAllOrdersOrderByIdDescImpl: FindAllOrdersOrderByIdDesc =
+  async ({ dbClient, pagination }) => {
+    const dbOrders = await dbClient.query.orderTable.findMany({
+      with: {
+        orderItems: true,
+      },
+      orderBy: [desc(orderTable.id)],
+      offset: pagination.offset,
+      limit: pagination.limit,
+    })
+    const orders = dbOrders.map((dbOrder) => ({
+      id: dbOrder.id,
+      customerName: dbOrder.customerName,
+      comment: dbOrder.comment,
+      createdAt: dbOrder.createdAt,
+      status: dbOrder.status,
+      updatedAt: dbOrder.updatedAt,
+      orderItems: dbOrder.orderItems.map((item) => ({
+        productId: item.productId,
+        productName: item.productName,
+        unitAmount: item.unitAmount,
+        quantity: item.quantity,
+      })),
+      totalAmount: dbOrder.totalAmount,
+    }))
+    return orders
+  }
 
 export const findAllOrdersByActiveStatusByUpdatedAtAscImpl: FindAllOrdersByActiveStatusOrderByUpdatedAtAsc =
   async ({ dbClient, pagination }) => {

--- a/app/routes/staff/orders/index.tsx
+++ b/app/routes/staff/orders/index.tsx
@@ -17,17 +17,20 @@ export default createRoute(async (c) => {
   const urlSearch = url.search
 
   const page = Math.max(1, parseInt(c.req.query("page") ?? "1", 10))
+  const sort = c.req.query("sort") === "desc" ? "desc" : "asc"
 
   const { orders, hasNextPage, currentPage } =
     await getOrdersManagementPageData({
       dbClient: c.get("dbClient"),
       page,
+      sort,
     })
 
   return c.render(
     <Layout title={"注文一覧"} description={"注文の一覧を表示します。"}>
       <ItemCollectionViewer
         title="注文一覧"
+        sort={sort}
         columns={[
           { header: "注文ID", align: "left" },
           { header: "登録日時", align: "left" },

--- a/app/usecases/exportOrderHistoryCsv.test.ts
+++ b/app/usecases/exportOrderHistoryCsv.test.ts
@@ -77,7 +77,7 @@ describe("exportOrderHistoryCsv", () => {
       },
     ]
 
-    spyOn(orderQueryRepository, "findAllOrders").mockImplementation(
+    spyOn(orderQueryRepository, "findAllOrdersOrderByIdAsc").mockImplementation(
       async ({ pagination }) => {
         if (pagination.offset === 0) {
           return orders
@@ -110,7 +110,7 @@ describe("exportOrderHistoryCsv", () => {
 
     const findAllSpy = spyOn(
       orderQueryRepository,
-      "findAllOrders",
+      "findAllOrdersOrderByIdAsc",
     ).mockImplementation(async ({ pagination }) => {
       if (pagination.offset === 0) {
         expect(pagination.limit).toBe(ORDER_HISTORY_EXPORT_PAGE_SIZE + 1)
@@ -140,7 +140,7 @@ describe("exportOrderHistoryCsv", () => {
       totalAmount: 0,
     })
 
-    spyOn(orderQueryRepository, "findAllOrders").mockImplementation(
+    spyOn(orderQueryRepository, "findAllOrdersOrderByIdAsc").mockImplementation(
       async () => [emptyOrder],
     )
 

--- a/app/usecases/exportOrderHistoryCsv.tsx
+++ b/app/usecases/exportOrderHistoryCsv.tsx
@@ -1,5 +1,5 @@
 import type Order from "../domain/order/entities/order"
-import { findAllOrders } from "../domain/order/repositories/orderQueryRepository"
+import { findAllOrdersOrderByIdAsc } from "../domain/order/repositories/orderQueryRepository"
 import type { DbClient } from "../infrastructure/db/client"
 import { toCsv } from "../utils/csv"
 
@@ -85,7 +85,7 @@ const fetchAllOrders = async (dbClient: DbClient): Promise<Order[]> => {
 
   // fetch in deterministic order by primary key via existing repository
   while (true) {
-    const chunk = await findAllOrders({
+    const chunk = await findAllOrdersOrderByIdAsc({
       dbClient,
       pagination: {
         offset: orders.length,

--- a/app/usecases/getOrdersManagementPageData.test.ts
+++ b/app/usecases/getOrdersManagementPageData.test.ts
@@ -55,15 +55,19 @@ const dbClient = {} as DbClient
 
 describe("getOrdersManagementPageData", () => {
   beforeAll(() => {
-    spyOn(orderQueryRepository, "findAllOrders").mockImplementation(
+    spyOn(orderQueryRepository, "findAllOrdersOrderByIdAsc").mockImplementation(
       async () => mockOrders,
     )
+    spyOn(
+      orderQueryRepository,
+      "findAllOrdersOrderByIdDesc",
+    ).mockImplementation(async () => mockOrders)
   })
   afterAll(() => {
     mock.restore()
   })
 
-  it("注文一覧を正しく取得できる", async () => {
+  it("注文一覧をデフォルト（昇順）で取得できる", async () => {
     const result = await getOrdersManagementPageData({ dbClient })
     expect(result.orders.length).toBe(3)
     expect(result.orders[0]?.id).toBe(1)
@@ -72,6 +76,17 @@ describe("getOrdersManagementPageData", () => {
     expect(result.hasNextPage).toBe(false)
     expect(result.currentPage).toBe(1)
     expect(result.pageSize).toBe(20)
+  })
+
+  it("sort='asc'で昇順を指定できる", async () => {
+    const result = await getOrdersManagementPageData({ dbClient, sort: "asc" })
+    expect(result.orders.length).toBe(3)
+    expect(result.orders[0]?.id).toBe(1)
+  })
+
+  it("sort='desc'で降順を指定できる", async () => {
+    const result = await getOrdersManagementPageData({ dbClient, sort: "desc" })
+    expect(result.orders.length).toBe(3)
   })
 
   it("pageSize+1を取得して次ページの有無を判定できる", async () => {
@@ -88,9 +103,10 @@ describe("getOrdersManagementPageData", () => {
       totalAmount: 1000,
     }))
 
-    spyOn(orderQueryRepository, "findAllOrders").mockImplementationOnce(
-      async () => manyOrders,
-    )
+    spyOn(
+      orderQueryRepository,
+      "findAllOrdersOrderByIdAsc",
+    ).mockImplementationOnce(async () => manyOrders)
 
     const result = await getOrdersManagementPageData({ dbClient })
     expect(result.orders.length).toBe(20)
@@ -112,9 +128,10 @@ describe("getOrdersManagementPageData", () => {
       totalAmount: 1000,
     }))
 
-    spyOn(orderQueryRepository, "findAllOrders").mockImplementationOnce(
-      async () => manyOrders,
-    )
+    spyOn(
+      orderQueryRepository,
+      "findAllOrdersOrderByIdAsc",
+    ).mockImplementationOnce(async () => manyOrders)
 
     const result = await getOrdersManagementPageData({ dbClient, page: 2 })
     expect(result.currentPage).toBe(2)

--- a/app/usecases/getOrdersManagementPageData.ts
+++ b/app/usecases/getOrdersManagementPageData.ts
@@ -1,10 +1,14 @@
 import type Order from "../domain/order/entities/order"
-import { findAllOrders } from "../domain/order/repositories/orderQueryRepository"
+import {
+  findAllOrdersOrderByIdAsc,
+  findAllOrdersOrderByIdDesc,
+} from "../domain/order/repositories/orderQueryRepository"
 import type { DbClient } from "../infrastructure/db/client"
 
 export type GetOrdersManagementPageDataParams = {
   dbClient: DbClient
   page?: number
+  sort?: "asc" | "desc"
 }
 
 export type OrdersManagementPageData = {
@@ -17,11 +21,14 @@ export type OrdersManagementPageData = {
 export const getOrdersManagementPageData = async ({
   dbClient,
   page = 1,
+  sort = "asc",
 }: GetOrdersManagementPageDataParams): Promise<OrdersManagementPageData> => {
   const pageSize = 20
   const offset = Math.max(0, (page - 1) * pageSize)
 
-  const ordersWithExtra = await findAllOrders({
+  const ordersWithExtra = await (sort === "asc"
+    ? findAllOrdersOrderByIdAsc
+    : findAllOrdersOrderByIdDesc)({
     dbClient,
     pagination: { offset, limit: pageSize + 1 },
   })


### PR DESCRIPTION
## 変更点

- 注文の一覧表示ページにソート順序を指定できるメニューを追加した

## 備考

- 注文以外のアイテム表示のソートの実装は範囲外