### PR TITLE
fix: improve error handling for missing `DATABASE_URL` in production environment

### DIFF
--- a/app/infrastructure/db/client.ts
+++ b/app/infrastructure/db/client.ts
@@ -31,10 +31,14 @@ export const createDbClient = async (): Promise<DbClient> => {
     try {
       // プロダクションビルドではPGliteを依存関係から除外する
       if (!process.env.DATABASE_URL) {
+        if (process.env.NODE_ENV === "production") {
+          throw new Error(
+            "DATABASE_URL environment variable is not set. Production environment requires a valid Postgres connection string.",
+          )
+        }
         if (!hasWarned) {
           console.warn(`DATABASE_URL environment variable is not set.
-Development environment will fall back to PGlite which provides a filesystem Postgres for development and testing.
-Production environment requires a valid Postgres connection string.`)
+Development environment will fall back to PGlite which provides a filesystem Postgres for development and testing.`)
           hasWarned = true
         }
 


### PR DESCRIPTION
## 変更点

- 本番環境では環境変数`DATABASE_URL`が未定義のときに`drizzle-orm/pglite`をインポートせずエラーを投げるようにした