### PR TITLE
chore: add git command for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM oven/bun:${BUN_VERSION} AS builder
 
 WORKDIR /app
 
+# Install git to embed commit hash at build time
 RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 
 COPY package.json bun.lock ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM oven/bun:${BUN_VERSION} AS builder
 
 WORKDIR /app
 
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## 変更点

- #254 の対応漏れで、コンテナをビルドする際に`git`が不足していたため追加した
