### PR TITLE
chore: disable Firefox and WebKit browsers in Playwright E2E tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,15 +35,15 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
 
-    {
-      name: "firefox",
-      use: { ...devices["Desktop Firefox"] },
-    },
+    // {
+    //   name: "firefox",
+    //   use: { ...devices["Desktop Firefox"] },
+    // },
 
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] },
-    },
+    // {
+    //   name: "webkit",
+    //   use: { ...devices["Desktop Safari"] },
+    // },
 
     /* Test against mobile viewports. */
     // {


### PR DESCRIPTION
## 変更点

- E2Eテストの実行時間短縮のため、一部のブラウザでのテストの実行を一時的に無効化した